### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ The **Pull requests** tab contains proposals to make some changes in the files l
 You can create an *Issue* or make a *Pull request (PR)* to contribute to the project.
 
 If you want to propose some changes to this repo, you may *fork* it, modify the content, and create *PR*. A *fork* is just a copy that allows you to change the content without affection the original project.
+Generate convenient .gitignore files for your project by the following web service https://www.toptal.com/developers/gitignore


### PR DESCRIPTION
added link for gitognore ( Gitignore.io is a web service designed to help you create .gitignore files for your Git repositories)