### PR TITLE
Fix .gitignore file: Add missing leading dot in file patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,8 @@ hs_err_pid*
 git.properties
 
 #IDEA Project Files
-*iml
-*iws
+*.iml
+*.iws
 .idea
-*ipr
-ishopdb
+*.ipr
+.ishopdb


### PR DESCRIPTION
I noticed an issue in the .gitignore file where the file patterns *iml, *iws, and ishopdb are missing the leading dot (.), which may prevent them from matching the intended files.

To address this problem, I made the necessary corrections by adding the leading dot in the file patterns. The corrected patterns are now *.iml, *.iws, and .ishopdb, ensuring that the .gitignore file functions as intended and properly excludes IntelliJ IDEA project files and the ishopdb directory.

Thanks,